### PR TITLE
Fix hash for small files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleport"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,7 +125,7 @@ pub fn run(opt: Opt) -> Result<(), Error> {
         );
 
         // Send header first
-        stream.write(&header.serialize())?;
+        stream.write_all(&header.serialize())?;
 
         // Receive response from server
         let recv = match recv_ack(&stream) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,7 @@ pub fn run(opt: Opt) -> Result<(), Error> {
 fn send_ack(ack: TeleportInitAck, mut stream: &TcpStream) -> Result<(), Error> {
     // Encode and send response
     let serial_resp = ack.serialize();
-    stream.write(&serial_resp)?;
+    stream.write_all(&serial_resp)?;
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -123,7 +123,7 @@ fn recv(mut stream: TcpStream, recv_list: Arc<Mutex<Vec<String>>>) -> Result<(),
     // If overwrite and file exists, build TeleportDelta
     let mut chunk_size = 5120;
     if meta.len() > 0 {
-        resp.delta = match utils::calc_delta_hash(&file, 0) {
+        resp.delta = match utils::calc_delta_hash(&file) {
             Ok(d) => {
                 chunk_size = d.delta_size + 1024;
                 Some(d)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,11 +57,16 @@ fn identify_unit(mut value: f64) -> SizeUnit {
 }
 
 fn gen_chunk_size(file_size: u64) -> usize {
-    if (file_size as usize / 100) < 1024 {
-        1024 * 1024
-    } else {
-        file_size as usize / 100
+    let mut chunk = 1024;
+    loop {
+        if file_size / chunk > 150 {
+            chunk *= 2;
+        } else {
+            break;
+        }
     }
+
+    chunk as usize
 }
 
 pub fn calc_file_hash(filename: String) -> Result<Hash, Error> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,12 +56,22 @@ fn identify_unit(mut value: f64) -> SizeUnit {
     }
 }
 
+fn gen_chunk_size(file_size: u64) -> usize {
+    if (file_size as usize / 100) < 1024 {
+        1024 * 1024
+    } else {
+        file_size as usize / 100
+    }
+}
+
 pub fn calc_file_hash(filename: String) -> Result<Hash, Error> {
     let mut hasher = blake3::Hasher::new();
     let mut buf = Vec::<u8>::new();
-    buf.resize(4096, 0);
 
     let mut file = File::open(filename)?;
+    let meta = file.metadata()?;
+
+    buf.resize(gen_chunk_size(meta.len()), 0);
 
     file.seek(SeekFrom::Start(0))?;
 
@@ -83,21 +93,13 @@ pub fn calc_file_hash(filename: String) -> Result<Hash, Error> {
     Ok(hasher.finalize())
 }
 
-pub fn calc_delta_hash(mut file: &File, delta_size: u64) -> Result<TeleportDelta, Error> {
+pub fn calc_delta_hash(mut file: &File) -> Result<TeleportDelta, Error> {
     let meta = file.metadata()?;
     let file_size = meta.len();
 
-    let chunk_size = if delta_size > 0 {
-        delta_size
-    } else if (file_size / 256) < 100 {
-        1024
-    } else {
-        file_size / 256
-    };
-
     file.seek(SeekFrom::Start(0))?;
     let mut buf = Vec::<u8>::new();
-    buf.resize(chunk_size as usize, 0);
+    buf.resize(gen_chunk_size(meta.len()), 0);
     let mut hasher = blake3::Hasher::new();
     let mut whole_hasher = blake3::Hasher::new();
     let mut delta_csum = Vec::<Hash>::new();
@@ -121,7 +123,7 @@ pub fn calc_delta_hash(mut file: &File, delta_size: u64) -> Result<TeleportDelta
 
     let out = TeleportDelta {
         size: file_size as u64,
-        delta_size: chunk_size as u64,
+        delta_size: buf.len() as u64,
         csum: whole_hasher.finalize(),
         delta_csum,
     };


### PR DESCRIPTION
The hash field was being generated two different ways for the server and client. Clean up implementation and just use 1 way.