### PR TITLE
Rename application to `teleporter` for crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+test/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/**
 test/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "teleport"
+name = "teleporter"
 version = "0.4.3"
 dependencies = [
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
-name = "teleport"
+name = "teleporter"
 version = "0.4.3"
+authors = ["geno nullfree <nullfree.geno@gmail.com>"]
+license = "BSD-3-Clause"
+description = "A small utility to send files quickly from point A to point B"
+readme = "README.md"
+homepage = "https://github.com/genonullfree/teleport.git"
+repository = "https://github.com/genonullfree/teleport.git"
+keywords = ["netcat", "teleport", "teleporter", "transfer", "send"]
+categories = ["command-line-utilities", "file-transfer-utilities"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://github.com/genonullfree/teleport.git"
 repository = "https://github.com/genonullfree/teleport.git"
 keywords = ["netcat", "teleport", "teleporter", "transfer", "send"]
-categories = ["command-line-utilities", "file-transfer-utilities"]
+categories = ["command-line-utilities", "network-programming"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Geno Nullfree
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Teleporter can recursively copy files as well, just pass a directory name and it
 
 Teleporter now does delta file transfers using the Blake3 hashing algorithm for files being overwritten.
 
+The protocol Teleporter implements to transfer files is called Teleport.
+
 # Usage
 ```
 Teleporter is a simple application for sending files from Point A to Point B

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Teleport
+# Teleporter
 
-Teleport is a small utility in the vein of netcat to send files quickly from point A to point B. It is more convenient than netcat in that you don't have to run a separate command with file redirection for each file you wish to transfer.
+Teleporter is a small utility in the vein of netcat to send files quickly from point A to point B. It is more convenient than netcat in that you don't have to run a separate command with file redirection for each file you wish to transfer.
 
-Teleport lets you pass the destination and a list of files you wish to send and it will create those files with the proper filenames on the receiving end. Each Teleport binary can act as a client or a server so there's no need to move multiple software packages around.
+Teleporter lets you pass the destination and a list of files you wish to send and it will create those files with the proper filenames on the receiving end. Each Teleporter binary can act as a client or a server so there's no need to move multiple software packages around.
 
-Teleport can recursively copy files as well, just pass a directory name and it will copy files all the way down.
+Teleporter can recursively copy files as well, just pass a directory name and it will copy files all the way down.
 
-Teleport now does delta file transfers using the Blake3 hashing algorithm for files being overwritten.
+Teleporter now does delta file transfers using the Blake3 hashing algorithm for files being overwritten.
 
 # Usage
 ```
-Teleport is a simple application for sending files from Point A to Point B
+Teleporter is a simple application for sending files from Point A to Point B
 
 USAGE:
-    teleport [FLAGS] [OPTIONS]
+    teleporter [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help         Prints help information
@@ -22,43 +22,43 @@ FLAGS:
     -V, --version      Prints version information
 
 OPTIONS:
-    -d, --dest <dest>         Destination teleport IP address [default: 127.0.0.1]
-    -i, --input <input>...    List of filepaths to files that will be teleported [default: ]
-    -p, --port <port>         Destination teleport Port, or Port to listen on [default: 9001]
+    -d, --dest <dest>         Destination teleporter IP address [default: 127.0.0.1]
+    -i, --input <input>...    List of filepaths to files that will be teleportered [default: ]
+    -p, --port <port>         Destination teleporter Port, or Port to listen on [default: 9001]
 ```
 
-To start a teleport in server (receiving) mode, just run:
+To start a teleporter in server (receiving) mode, just run:
 ```
-./teleport
+./teleporter
 ```
 or
 ```
 cargo run
 ```
-Teleport will default to listening on `0.0.0.0:9001` for incoming connections.
+Teleporter will default to listening on `0.0.0.0:9001` for incoming connections.
 
-To start a teleport in client (sending) mode, run:
+To start a teleporter in client (sending) mode, run:
 ```
-./teleport -d <destination IP> -i <file> [[file2] [file3] ...]
+./teleporter -d <destination IP> -i <file> [[file2] [file3] ...]
 ```
 
-Teleport will transfer files with their name information as well as their file permissions. Any file path information will be lost. All the received files will be written out in the CWD where the server side was started.
+Teleporter will transfer files with their name information as well as their file permissions. Any file path information will be lost. All the received files will be written out in the CWD where the server side was started.
 
 # Installation
 
-If you have Rust and Cargo installed, Teleport can be quickly compiled and installed by running the following command:
+If you have Rust and Cargo installed, Teleporter can be quickly compiled and installed by running the following command:
 ```
-cargo install --git https://github.com/genonullfree/teleport.git
+cargo install teleporterer
 ```
-This will install Teleport to `~/.cargo/bin/teleport`, which might need to be added to your shell's `PATH` variable.
+This will install Teleporter to `~/.cargo/bin/teleporter`, which might need to be added to your shell's `PATH` variable.
 
 # Example output
 
 ## Server (receiving from 2 different clients)
 
 ```
-$ target/debug/teleport
-Teleport Server listening for connections on 0.0.0.0:9001
+$ target/debug/teleporter
+Teleporter Server listening for connections on 0.0.0.0:9001
 Receiving: ["testfile", "otherfile", "testfile2", "testfile3"] => Received file: testfile2 from: 127.0.0.1:41330
 Receiving: ["testfile", "otherfile", "testfile3", "testfile4"] => Received file: testfile3 from: 127.0.0.1:41332
 Receiving: ["testfile", "otherfile", "testfile4"] => Received file: testfile from: 127.0.0.1:41326
@@ -71,8 +71,8 @@ Receiving: ["otherfile", "testfileC"]
 ## Client (sending)
 
 ```
-$ target/debug/teleport -i ./test/testfile ./test/testfile2 ./test/testfile3 ./test/testfile4
-Teleport Client
+$ target/debug/teleporter -i ./test/testfile ./test/testfile2 ./test/testfile3 ./test/testfile4
+Teleporter Client
 Sending file 1/4: "testfile"
  =>    2.000G of    2.000G (100.00%) done!
 Sending file 2/4: "testfile2"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Teleporter will transfer files with their name information as well as their file
 
 If you have Rust and Cargo installed, Teleporter can be quickly compiled and installed by running the following command:
 ```
-cargo install teleporterer
+cargo install teleporter
 ```
 This will install Teleporter to `~/.cargo/bin/teleporter`, which might need to be added to your shell's `PATH` variable.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Teleport lets you pass the destination and a list of files you wish to send and 
 
 Teleport can recursively copy files as well, just pass a directory name and it will copy files all the way down.
 
-Teleport now does delta file transfers using the Blake3 hashing algorithm for files being overwritten that are larger than 1Mb. Testing has shown this to increase speedup for large files by about half.
+Teleport now does delta file transfers using the Blake3 hashing algorithm for files being overwritten.
 
 # Usage
 ```
@@ -44,6 +44,14 @@ To start a teleport in client (sending) mode, run:
 
 Teleport will transfer files with their name information as well as their file permissions. Any file path information will be lost. All the received files will be written out in the CWD where the server side was started.
 
+# Installation
+
+If you have Rust and Cargo installed, Teleport can be quickly compiled and installed by running the following command:
+```
+cargo install --git https://github.com/genonullfree/teleport.git
+```
+This will install Teleport to `~/.cargo/bin/teleport`, which might need to be added to your shell's `PATH` variable.
+
 # Example output
 
 ## Server (receiving from 2 different clients)
@@ -75,7 +83,3 @@ Sending file 4/4: "testfile4"
  =>   20.000M of   20.000M (100.00%) done!
 
 ```
-
-# WIP Disclaimer
-
-Teleport is currently a work in progress. Use at your own risk.

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,7 +51,7 @@ fn scope_dir(dir: &Path) -> Result<Vec<String>, Error> {
 
 /// Client function sends filename and file data for each filepath
 pub fn run(opt: Opt) -> Result<(), Error> {
-    println!("Teleport Client {}", VERSION);
+    println!("Teleporter Client {}", VERSION);
 
     let files = get_file_list(&opt);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod client;
 mod server;
 mod utils;
 
-/// Teleport is a simple application for sending files from Point A to Point B
+/// Teleporter is a simple application for sending files from Point A to Point B
 
 #[derive(Debug, StructOpt)]
 pub struct Opt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,11 @@ pub struct Opt {
     #[structopt(short, long, parse(from_os_str), default_value = "")]
     input: Vec<PathBuf>,
 
-    /// Destination teleport IP address
+    /// Destination teleporter IP address
     #[structopt(short, long, default_value = "127.0.0.1")]
     dest: String,
 
-    /// Destination teleport Port, or Port to listen on
+    /// Destination teleporter Port, or Port to listen on
     #[structopt(short, long, default_value = "9001")]
     port: u16,
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,7 @@ pub fn run(opt: Opt) -> Result<(), Error> {
     };
 
     println!(
-        "Teleport Server {} listening for connections on 0.0.0.0:{}",
+        "Teleporter Server {} listening for connections on 0.0.0.0:{}",
         VERSION, &opt.port
     );
 


### PR DESCRIPTION
Update docs, license file, and `Cargo.toml` to push project to https://crates.io/crates/teleporter

Also renamed the application from `teleport` to `teleporter` for crates.io.

This will help define the protocol itself as `teleport` and this particular application implementing the protocol as `teleporter`.