### PR TITLE
Bump msrv to 1.56

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,35 +10,66 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-  
+  linux-check:
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      
-      # Build and Test
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-        
-      # Setup Rust compiler for release builds
-      - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1.0.4
+      - uses: actions-rs/cargo@v1
         with:
-          # The version to install
-          rust-version: 1.56.0
-          # The targets to install
-          targets: x86_64-unknown-linux-gnu
-      - name: Build (Release) linux-x86_64
-        run: cargo build --release --verbose --target x86_64-unknown-linux-gnu
-      - name: Upload linux-x86_64 release
-        uses: actions/upload-artifact@v2.2.4
+          command: build
+            
+  linux-test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  linux-fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+  linux-release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: actions/upload-artifact@v2.2.4
         with:
           name: teleporter-linux-x86_64
           path: target/x86_64-unknown-linux-gnu/release/teleporter

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,26 +15,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    
-    # Build and Test
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       
-    # Setup Rust compiler for release builds
-    - name: Setup Rust
-      uses: ATiltedTree/setup-rust@v1.0.4
-      with:
-        # The version to install
-        rust-version: 1.56.0
-        # The targets to install
-        targets: x86_64-unknown-linux-gnu
-    - name: Build (Release) linux-x86_64
-      run: cargo build --release --verbose --target x86_64-unknown-linux-gnu
-    - name: Upload linux-x86_64 release
-      uses: actions/upload-artifact@v2.2.4
-      with:
-        name: teleporter-linux-x86_64
-        path: target/x86_64-unknown-linux-gnu/release/teleporter
+      # Build and Test
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+        
+      # Setup Rust compiler for release builds
+      - name: Setup Rust
+        uses: ATiltedTree/setup-rust@v1.0.4
+        with:
+          # The version to install
+          rust-version: 1.56.0
+          # The targets to install
+          targets: x86_64-unknown-linux-gnu
+      - name: Build (Release) linux-x86_64
+        run: cargo build --release --verbose --target x86_64-unknown-linux-gnu
+      - name: Upload linux-x86_64 release
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: teleporter-linux-x86_64
+          path: target/x86_64-unknown-linux-gnu/release/teleporter

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,4 +72,4 @@ jobs:
       - uses: actions/upload-artifact@v2.2.4
         with:
           name: teleporter-linux-x86_64
-          path: target/x86_64-unknown-linux-gnu/release/teleporter
+          path: target/release/teleporter

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/genonullfree/teleport.git"
 repository = "https://github.com/genonullfree/teleport.git"
 keywords = ["netcat", "teleport", "teleporter", "transfer", "send"]
 categories = ["command-line-utilities", "network-programming"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use byteorder::{LittleEndian, ReadBytesExt};
-use std::convert::{TryFrom, TryInto};
 
 struct SizeUnit {
     value: f64,


### PR DESCRIPTION
This allows removal of `std::convert::{TryFrom, TryInfo}` since they are included in the `std::prelude`.

Notice that they will receive the following error if not using =>1.56:
```
> cargo +1.55.0-x86_64-unknown-linux-gnu b
error: failed to parse manifest at `/home/wcampbell/projects/wcampbell/code/teleport/Cargo.toml`

Caused by:
  feature `edition2021` is required

  The package requires the Cargo feature called `edition2021`, but that feature is not stabilized in this version of Cargo (1.55.0 (32da73ab1 2021-08-23)).

  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2021 for more information about the status of this feature.
```

But the future is here!