### PR TITLE
Implement XXH3 for the delta and file hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,18 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,30 +64,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake3"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd555c66291d5f836dbb6883b48660ece810fe25a31f3bdfb911945dff2691f"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "cc"
-version = "1.0.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -141,12 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,15 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -429,16 +382,16 @@ dependencies = [
 
 [[package]]
 name = "teleporter"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
- "blake3",
  "byteorder",
  "generic-array",
  "rand 0.5.6",
  "rust-crypto",
  "semver",
  "structopt",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -534,3 +487,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575e15bedf6e57b5c2d763ffc6c3c760143466cbd09d762d539680ab5992ded"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 structopt = "0.3.13"
 byteorder = "1.4.3"
-blake3 = "1.0.0"
+xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 rust-crypto = "^0.2"
 rand = "0.5"
 generic-array = "0.14.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,9 @@ use crate::teleport::{TeleportAction, TeleportFeatures, TeleportStatus};
 use crate::teleport::{TeleportInit, TeleportInitAck};
 use crate::utils::print_updates;
 use crate::*;
+use std::hash::Hasher;
 use std::path::Path;
+use xxhash_rust::xxh3;
 
 #[derive(Debug)]
 struct Replace {
@@ -243,13 +245,13 @@ pub fn run(mut opt: Opt) -> Result<(), Error> {
             _ => (),
         };
 
-        let csum_recv = recv.delta.as_ref().map(|r| r.checksum);
-        let mut checksum: Option<Hash> = None;
+        let csum_recv = recv.delta.as_ref().map(|r| r.hash);
+        let mut hash: Option<u64> = None;
         if utils::check_feature(&recv.features, TeleportFeatures::Overwrite) {
-            checksum = handle.map(|s| s.join().expect("calc_file_hash panicked"));
+            hash = handle.map(|s| s.join().expect("calc_file_hash panicked"));
         }
 
-        if checksum != None && checksum == csum_recv {
+        if hash != None && hash == csum_recv {
             // File matches hash
             send_data_complete(stream, &enc, file)?;
         } else {
@@ -292,12 +294,11 @@ fn send(
     delta: Option<TeleportDelta>,
 ) -> Result<(), Error> {
     let mut buf = Vec::<u8>::new();
-    let mut hash_list = Vec::<Hash>::new();
-    let mut hasher = blake3::Hasher::new();
+    let mut hash_list = Vec::<u64>::new();
     match delta {
         Some(d) => {
             buf.resize(d.chunk_size as usize, 0);
-            hash_list = d.delta_checksum;
+            hash_list = d.chunk_hash;
         }
         None => buf.resize(4096, 0),
     }
@@ -319,12 +320,12 @@ fn send(
         // Check if hash matches, if so: skip chunk
         let index = sent / buf.len();
         if !hash_list.is_empty() && index < hash_list.len() {
-            hasher.update(&buf);
-            if hash_list[index] == hasher.finalize() {
+            let mut hasher = xxh3::Xxh3::new();
+            hasher.write(&buf);
+            if hash_list[index] == hasher.finish() {
                 sent += len;
                 continue;
             }
-            hasher.reset();
         }
 
         let data = &buf[..len];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use blake3::Hash;
 use semver::Version;
 use std::fs::File;
 use std::io::{self, Read, Write};

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -377,28 +377,28 @@ impl TeleportInitAck {
 #[derive(Clone, Debug, PartialEq)]
 pub struct TeleportDelta {
     pub filesize: u64,
-    pub checksum: Hash,
+    pub hash: u64,
     pub chunk_size: u64,
-    delta_checksum_len: u16,
-    pub delta_checksum: Vec<Hash>,
+    chunk_hash_len: u16,
+    pub chunk_hash: Vec<u64>,
 }
 
 impl TeleportDelta {
     pub fn new() -> TeleportDelta {
         TeleportDelta {
             filesize: 0,
-            checksum: [0; 32].try_into().unwrap(),
+            hash: 0,
             chunk_size: 0,
-            delta_checksum_len: 0,
-            delta_checksum: Vec::<Hash>::new(),
+            chunk_hash_len: 0,
+            chunk_hash: Vec::<u64>::new(),
         }
     }
 
-    fn delta_serial(input: &[Hash]) -> Vec<u8> {
+    fn delta_serial(input: &[u64]) -> Vec<u8> {
         let mut out = Vec::<u8>::new();
 
         for i in input {
-            out.append(&mut i.as_bytes().to_vec());
+            out.append(&mut i.to_le_bytes().to_vec());
         }
 
         out
@@ -411,35 +411,36 @@ impl TeleportDelta {
         out.append(&mut self.filesize.to_le_bytes().to_vec());
 
         // Add file hash
-        out.append(&mut self.checksum.as_bytes().to_vec());
+        out.append(&mut self.hash.to_le_bytes().to_vec());
 
         // Add chunk size
         out.append(&mut self.chunk_size.to_le_bytes().to_vec());
 
         // Add delta vector length
-        let dlen = self.delta_checksum.len() as u16;
+        let dlen = self.chunk_hash.len() as u16;
         out.append(&mut dlen.to_le_bytes().to_vec());
 
         // Add delta vector
-        out.append(&mut TeleportDelta::delta_serial(&self.delta_checksum));
+        out.append(&mut TeleportDelta::delta_serial(&self.chunk_hash));
 
         out
     }
 
-    fn delta_deserial(input: &[u8]) -> Result<Vec<Hash>, Error> {
-        if input.len() % 32 != 0 {
+    fn delta_deserial(input: &[u8], len: u16) -> Result<Vec<u64>, Error> {
+        if input.len() % 8 != 0 || len as usize != input.len() / 8 {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                "Cannot deserialize Vec<Hash>",
+                "Cannot deserialize Vec<u64>",
             ));
         }
 
-        let mut out = Vec::<Hash>::new();
-
-        for i in input.chunks(32) {
-            let a: [u8; 32] = i.try_into().unwrap();
-            let h: Hash = a.try_into().unwrap();
-            out.push(h);
+        let mut out = Vec::<u64>::new();
+        let mut buf = input;
+        let mut count: u16 = len;
+        while count > 0 {
+            let a: u64 = buf.read_u64::<LittleEndian>().unwrap();
+            out.push(a);
+            count -= 1;
         }
 
         Ok(out)
@@ -448,7 +449,7 @@ impl TeleportDelta {
     pub fn deserialize(&mut self, input: &[u8]) -> Result<(), Error> {
         let mut buf: &[u8] = input;
 
-        if input.len() < 50 {
+        if input.len() < 26 {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "Not enough data for Delta deserialize",
@@ -458,18 +459,16 @@ impl TeleportDelta {
         self.filesize = buf.read_u64::<LittleEndian>().unwrap();
 
         // Extract file hash
-        let csum: [u8; 32] = input[8..40].try_into().unwrap();
-        self.checksum = csum.try_into().unwrap();
-        let mut buf: &[u8] = &input[40..];
+        self.hash = buf.read_u64::<LittleEndian>().unwrap();
 
         // Extract chunk size
         self.chunk_size = buf.read_u64::<LittleEndian>().unwrap();
 
         // Extract delta vector length
-        self.delta_checksum_len = buf.read_u16::<LittleEndian>().unwrap();
+        self.chunk_hash_len = buf.read_u16::<LittleEndian>().unwrap();
 
         // Extract delta vector
-        self.delta_checksum = TeleportDelta::delta_deserial(&input[50..]).unwrap();
+        self.chunk_hash = TeleportDelta::delta_deserial(buf, self.chunk_hash_len).unwrap();
 
         Ok(())
     }
@@ -545,8 +544,7 @@ mod tests {
         101,
     ];
     const TESTDELTA: &[u8] = &[
-        177, 104, 222, 58, 0, 0, 0, 0, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 21, 205, 91, 7, 0, 0, 0, 0, 0, 0,
+        177, 104, 222, 58, 0, 0, 0, 0, 57, 48, 0, 0, 0, 0, 0, 0, 21, 205, 91, 7, 0, 0, 0, 0, 0, 0,
     ];
     const TESTDATAPKT: &[u8] = &[49, 212, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1, 2, 3, 4, 5];
     const TESTINITACK: &[u8] = &[0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0];
@@ -643,9 +641,9 @@ mod tests {
     fn test_teleportdelta_serialize() {
         let mut test = TeleportDelta::new();
         test.filesize = 987654321;
-        test.checksum = [5; 32].try_into().unwrap();
+        test.hash = 12345;
         test.chunk_size = 123456789;
-        test.delta_checksum = Vec::<Hash>::new();
+        test.chunk_hash = Vec::<u64>::new();
 
         let out = test.serialize();
 
@@ -656,9 +654,9 @@ mod tests {
     fn test_teleportdelta_deserialize() {
         let mut test = TeleportDelta::new();
         test.filesize = 987654321;
-        test.checksum = [5; 32].try_into().unwrap();
+        test.hash = 12345;
         test.chunk_size = 123456789;
-        test.delta_checksum = Vec::<Hash>::new();
+        test.chunk_hash = Vec::<u64>::new();
 
         let mut t = TeleportDelta::new();
         t.deserialize(TESTDELTA).unwrap();


### PR DESCRIPTION
This change will require changing the protocol fields, but cleans
up the serializeation/deserialization functions. It also speeds
up the hashing and comparisons due to it being a 64bit hash instead
of a 32byte hash. According to:
https://github.com/Cyan4973/xxHash/wiki/Collision-ratio-comparison
and
https://github.com/Cyan4973/xxHash/wiki/Performance-comparison
the XXH3 hash is extremely fast and has a low collision rate.

Also increase the number of chunks that we support from up to 150
per file to 2048.

Closes #61 