### PR TITLE
Bug/update ecdh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,15 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,16 +118,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "curve25519-dalek"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
+name = "digest"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "generic-array"
@@ -146,6 +147,28 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -207,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,82 +279,52 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand 0.4.6",
+ "rand_chacha",
+ "rand_core 0.6.3",
+ "rand_hc",
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "rand_core 0.3.1",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
+name = "rand_core"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
+name = "rand_hc"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
 
 [[package]]
 name = "semver"
@@ -381,16 +380,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "teleporter"
 version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "byteorder",
  "generic-array",
- "rand 0.5.6",
- "rust-crypto",
+ "rand",
+ "rand_core 0.5.1",
  "semver",
  "structopt",
+ "x25519-dalek",
  "xxhash-rust",
 ]
 
@@ -401,17 +413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
 ]
 
 [[package]]
@@ -462,9 +463,15 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
@@ -489,7 +496,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "x25519-dalek"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575e15bedf6e57b5c2d763ffc6c3c760143466cbd09d762d539680ab5992ded"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "teleporter"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ edition = "2021"
 structopt = "0.3.13"
 byteorder = "1.4.3"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
-rust-crypto = "^0.2"
-rand = "0.5"
-generic-array = "0.14.4"
 aes-gcm = "0.9.4"
+generic-array = "0.14.4"
+x25519-dalek = "1.2.0"
 semver = "1.0.4"
+rand = "0.8.4"
+rand_core = { version = "0.5", default-features = false }

--- a/src/client.rs
+++ b/src/client.rs
@@ -193,10 +193,12 @@ pub fn run(mut opt: Opt) -> Result<(), Error> {
 
         if opt.encrypt {
             let mut ctx = TeleportEnc::new();
+            let privkey = crypto::genkey(&mut ctx);
             utils::send_packet(&mut stream, TeleportAction::Ecdh, &None, ctx.serialize())?;
             let packet = utils::recv_packet(&mut stream, &None)?;
             if packet.action == TeleportAction::EcdhAck as u8 {
                 ctx.deserialize(&packet.data)?;
+                ctx.calc_secret(privkey);
                 enc = Some(ctx);
             }
         }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,21 +1,16 @@
+use crate::teleport::TeleportEnc;
 use crate::{Error, ErrorKind};
 use aes_gcm::aead::{Aead, NewAead};
 use aes_gcm::{Aes256Gcm, Key};
-use crypto::ed25519::{exchange, keypair};
 use generic_array::GenericArray;
-use rand::prelude::*;
+use rand_core::OsRng;
+use x25519_dalek::{EphemeralSecret, PublicKey};
 
-pub fn genkey() -> ([u8; 64], [u8; 32]) {
-    let mut rng = StdRng::from_entropy();
+pub fn genkey(ctx: &mut TeleportEnc) -> EphemeralSecret {
+    let secret = EphemeralSecret::new(OsRng);
+    ctx.public.key = PublicKey::from(&secret).to_bytes();
 
-    let mut seed: [u8; 32] = [0; 32];
-    rng.fill(&mut seed);
-
-    keypair(&seed)
-}
-
-pub fn calc_secret(public: &[u8; 32], private: &[u8; 64]) -> [u8; 32] {
-    exchange(public, private)
+    secret
 }
 
 pub fn decrypt(key: &[u8; 32], nonce: Vec<u8>, data: Vec<u8>) -> Result<Vec<u8>, Error> {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -8,7 +8,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 
 pub fn genkey(ctx: &mut TeleportEnc) -> EphemeralSecret {
     let secret = EphemeralSecret::new(OsRng);
-    ctx.public.key = PublicKey::from(&secret).to_bytes();
+    ctx.public = PublicKey::from(&secret).to_bytes();
 
     secret
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,7 +88,9 @@ fn recv(
     let mut packet = utils::recv_packet(&mut stream, &None)?;
     if packet.action == TeleportAction::Ecdh as u8 {
         let mut ctx = TeleportEnc::new();
+        let privkey = crypto::genkey(&mut ctx);
         ctx.deserialize(&packet.data)?;
+        ctx.calc_secret(privkey);
         utils::send_packet(&mut stream, TeleportAction::EcdhAck, &None, ctx.serialize())?;
         enc = Some(ctx);
         packet = utils::recv_packet(&mut stream, &enc)?;

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -102,12 +102,7 @@ impl TeleportHeader {
 pub struct TeleportEnc {
     secret: [u8; 32],
     remote: [u8; 32],
-    pub public: TeleportEcdhExchange,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct TeleportEcdhExchange {
-    pub key: [u8; 32],
+    pub public: [u8; 32],
 }
 
 impl TeleportEnc {
@@ -115,12 +110,12 @@ impl TeleportEnc {
         TeleportEnc {
             secret: [0; 32],
             remote: [0; 32],
-            public: TeleportEcdhExchange { key: [0; 32] },
+            public: [0; 32],
         }
     }
 
     pub fn serialize(self) -> Vec<u8> {
-        self.public.key.to_vec()
+        self.public.to_vec()
     }
 
     pub fn deserialize(&mut self, input: &[u8]) -> Result<(), Error> {


### PR DESCRIPTION
Closes #69 


`cargo audit` scans clean now

```bash
% cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 374 security advisories (from /Users/geno/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (59 crate dependencies)
%
```