### PR TITLE
Set max chunk size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "teleporter"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -133,7 +133,7 @@ values are specific error scenarios that cause the client to not proceed with th
 pub struct TeleportDelta {
     filesize: u64,
     hash: u64,
-    chunk_size: u64,
+    chunk_size: u32,
     chunk_hash_len: u16,
     chunk_hash: Vec<u64>,
 }
@@ -143,9 +143,10 @@ struct is constructed to inform to the client what chunks need to be sent to the
 a delta file transfer. Delta file transfers can save valuable time by only transferring parts of
 the file that are different. The `filesize` value is sent to indicate what the size of the file that
 exists on the server is, to be compared with the file size on the client. The `chunk_size` relates
-how large of blocks of data are to be used for the delta chunks. `hash` is a xxHash3 hash value of
-the entire file on the server, and `chunk_hash` is a vector of xxHash3 hash values for each chunk
-of length `chunk_size` in the file. The xxHash3 hash values are 8 bytes in length and are stored as u64.
+how large blocks of data are to be used for the delta chunks, with a max chunk size of 4GB. `hash` is a
+xxHash3 hash value of the entire file on the server, and `chunk_hash` is a vector of xxHash3 hash values
+for each chunk of length `chunk_size` in the file. The xxHash3 hash values are 8 bytes in length and are
+stored as u64.
 
 Once the server replies back to the client with a `Proceed` `TeleportInitAck` packet,
 the client will begin sending data. If the server sent an `Overwrite` feature back, then the client will

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,7 +204,7 @@ pub fn run(mut opt: Opt) -> Result<(), Error> {
         println!("Sending file {}/{}: {}", num + 1, files.len(), &filename);
 
         // Send header first
-        utils::send_packet(&mut stream, TeleportAction::Init, &enc, header.serialize())?;
+        utils::send_packet(&mut stream, TeleportAction::Init, &enc, header.serialize()?)?;
 
         // Receive response from server
         let packet = utils::recv_packet(&mut stream, &enc)?;
@@ -284,7 +284,7 @@ fn send_data_complete(
     };
 
     // Send the data chunk
-    utils::send_packet(&mut stream, TeleportAction::Data, enc, chunk.serialize())?;
+    utils::send_packet(&mut stream, TeleportAction::Data, enc, chunk.serialize()?)?;
 
     Ok(())
 }
@@ -351,7 +351,7 @@ fn send(
         };
 
         // Send the data chunk
-        utils::send_packet(&mut stream, TeleportAction::Data, enc, chunk.serialize())?;
+        utils::send_packet(&mut stream, TeleportAction::Data, enc, chunk.serialize()?)?;
 
         sent += len;
         print_updates(sent as f64, header);

--- a/src/server.rs
+++ b/src/server.rs
@@ -53,11 +53,11 @@ pub fn run(opt: Opt) -> Result<(), Error> {
 
 fn send_ack(
     ack: TeleportInitAck,
-    mut stream: &mut TcpStream,
+    stream: &mut TcpStream,
     enc: &Option<TeleportEnc>,
 ) -> Result<(), Error> {
     // Encode and send response
-    utils::send_packet(&mut stream, TeleportAction::InitAck, enc, ack.serialize())
+    utils::send_packet(stream, TeleportAction::InitAck, enc, ack.serialize()?)
 }
 
 fn print_list(list: &MutexGuard<Vec<String>>) {

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -447,7 +447,7 @@ impl TeleportDelta {
     pub fn deserialize(&mut self, input: &[u8]) -> Result<(), Error> {
         let mut buf: &[u8] = input;
 
-        if input.len() < 26 {
+        if input.len() < 22 {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "Not enough data for Delta deserialize",
@@ -542,7 +542,7 @@ mod tests {
         101,
     ];
     const TESTDELTA: &[u8] = &[
-        177, 104, 222, 58, 0, 0, 0, 0, 57, 48, 0, 0, 0, 0, 0, 0, 21, 205, 91, 7, 0, 0, 0, 0, 0, 0,
+        177, 104, 222, 58, 0, 0, 0, 0, 57, 48, 0, 0, 0, 0, 0, 0, 21, 205, 91, 7, 0, 0,
     ];
     const TESTDATAPKT: &[u8] = &[49, 212, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1, 2, 3, 4, 5];
     const TESTINITACK: &[u8] = &[0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0];
@@ -553,7 +553,7 @@ mod tests {
         t.data.append(&mut TESTDATA.to_vec());
         t.action |= TeleportAction::Encrypted as u8;
         t.iv = Some(*TESTHEADERIV);
-        let s = t.serialize();
+        let s = t.serialize().unwrap();
         assert_eq!(s, TESTHEADER);
     }
 
@@ -622,7 +622,7 @@ mod tests {
         test.chmod = 0o755;
         test.features |= TeleportFeatures::Overwrite as u32;
 
-        let out = test.serialize();
+        let out = test.serialize().unwrap();
         assert_eq!(out, TESTINIT);
     }
 
@@ -651,7 +651,7 @@ mod tests {
         test.chunk_size = 123456789;
         test.chunk_hash = Vec::<u64>::new();
 
-        let out = test.serialize();
+        let out = test.serialize().unwrap();
 
         assert_eq!(out, TESTDELTA);
     }
@@ -677,7 +677,7 @@ mod tests {
         test.data_len = 5;
         test.data = vec![1, 2, 3, 4, 5];
 
-        let out = test.serialize();
+        let out = test.serialize().unwrap();
 
         assert_eq!(out, TESTDATAPKT);
     }
@@ -701,7 +701,7 @@ mod tests {
         let feat = TeleportFeatures::NewFile as u32 | TeleportFeatures::Overwrite as u32;
         test.features = Some(feat);
         test.version = [0, 6, 0];
-        let out = test.serialize();
+        let out = test.serialize().unwrap();
 
         assert_eq!(out, TESTINITACK);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,7 +87,7 @@ pub fn send_packet(
     }
 
     // Serialize the message
-    let message = header.serialize();
+    let message = header.serialize()?;
 
     // Send the packet
     sock.write_all(&message)?;
@@ -152,7 +152,11 @@ fn gen_chunk_size(file_size: u64) -> usize {
         }
     }
 
-    chunk as usize
+    if chunk > u32::MAX as u64 {
+        u32::MAX as usize
+    } else {
+        chunk as usize
+    }
 }
 
 pub fn add_feature(opt: &mut Option<u32>, add: TeleportFeatures) -> Result<(), Error> {
@@ -206,7 +210,7 @@ pub fn calc_delta_hash(mut file: &File) -> Result<teleport::TeleportDelta, Error
 
     let mut out = teleport::TeleportDelta::new();
     out.filesize = file_size as u64;
-    out.chunk_size = buf.len() as u64;
+    out.chunk_size = buf.len().try_into().unwrap();
     out.hash = whole_hasher.finish();
     out.chunk_hash = chunk_hash;
 


### PR DESCRIPTION
Set the maximum chunk size to be 4GB for delta chunks and file
transfers. Realistically it will not get this large unless there is
a crazy huge file transfer going on anyway.

Check that the length values are within the bounds of the fields
we are sending in.